### PR TITLE
Fix dialogue width for 'Hi cutey!' line

### DIFF
--- a/script.js
+++ b/script.js
@@ -256,7 +256,7 @@ function drawWorldExtras() {
     ctx.textBaseline = "top";
     const lineHeight = 14;
     const padding = 4;
-    const lines = getWrappedLines(ctx, showTypedMessage, 120);
+    const lines = getWrappedLines(ctx, showTypedMessage, 150);
     let maxLineWidth = 0;
     for (const l of lines) {
       maxLineWidth = Math.max(maxLineWidth, ctx.measureText(l).width);


### PR DESCRIPTION
## Summary
- widen dialogue text wrapping width so "Hi cutey!" fits on one line

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c87dcb9dc8328b8ad43bf10fbaae7