### PR TITLE
Remove debug UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,9 +23,7 @@
 <button class="btn" onmousedown="startMove('down')" onmouseup="stopMove('down')" ontouchend="stopMove('down')" ontouchstart="startMove('down')">⬇️</button>
 <button class="btn" onmousedown="startMove('right')" onmouseup="stopMove('right')" ontouchend="stopMove('right')" ontouchstart="startMove('right')">➡️</button>
 </div>
-<button class="btn" id="debug-toggle" aria-label="Toggle debug log">🐞</button>
 </div>
-<div id="debug-log"></div>
 <audio autoplay="" id="bg-music" loop="" src="assets/music.mp3">
     Your browser does not support the audio element.
 </audio>

--- a/script.js
+++ b/script.js
@@ -809,25 +809,3 @@ function gameLoop() {
 updateDialogue();
 gameLoop();
 
-const debugLog = document.getElementById('debug-log');
-const debugToggle = document.getElementById('debug-toggle');
-if (debugToggle) {
-  debugToggle.addEventListener('click', () => {
-    if (!debugLog) return;
-    debugLog.style.display = debugLog.style.display === 'block' ? 'none' : 'block';
-  });
-}
-
-function logDebug(msg) {
-  if (!debugLog) return;
-  const entry = document.createElement('div');
-  entry.textContent = msg;
-  debugLog.appendChild(entry);
-  if (debugLog.children.length > 20) {
-    debugLog.removeChild(debugLog.firstChild);
-  }
-}
-
-window.addEventListener('error', (e) => {
-  logDebug(`ERR: ${e.message} (${e.filename}:${e.lineno})`);
-});

--- a/style.css
+++ b/style.css
@@ -74,19 +74,3 @@
   transition: opacity 0.3s ease;
 }
 
-#debug-log {
-  position: fixed;
-  bottom: 10px;
-  right: 10px;
-  width: 200px;
-  max-height: 120px;
-  overflow-y: auto;
-  background: rgba(0, 0, 0, 0.8);
-  color: #0f0;
-  font-size: 10px;
-  font-family: monospace;
-  padding: 4px;
-  border: 1px solid #555;
-  display: none;
-  z-index: 1000;
-}


### PR DESCRIPTION
## Summary
- remove debug button and log container
- drop debug toggle logic from script
- delete debug log styling

## Testing
- `node - <<'EOF'
const puppeteer = require('puppeteer');
(async () => {
  const browser = await puppeteer.launch({args:['--no-sandbox']});
  const page = await browser.newPage();
  page.on('console', msg => console.log('PAGE LOG:', msg.text()));
  page.on('pageerror', err => console.log('PAGE ERROR:', err.message));
  await page.goto('file://' + process.cwd() + '/index.html');
  await page.evaluate(() => console.log('Game loaded'));
  await new Promise(res => setTimeout(res, 500));
  await browser.close();
})();
EOF

------
https://chatgpt.com/codex/tasks/task_e_686ca91beb108328a18b5242ae90a0ad