### PR TITLE
Fix start screen and sounds

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,13 +8,11 @@
 
 
 <link href="style.css" rel="stylesheet"/>
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self'; media-src 'self'; style-src 'self'; script-src 'self'"/>
-<meta http-equiv="X-Content-Type-Options" content="nosniff"/>
 </head>
 <body>
 <!-- Embedded Start Screen Image -->
 <div id="startScreen">
-<img alt="Tap to Start" src="assets/start.png" crossorigin="anonymous"/>
+<img alt="Tap to Start" src="assets/start.png"/>
 </div>
 
 <div id="flower-popup">Flowers Collected!</div>
@@ -27,11 +25,11 @@
 <button class="btn" onmousedown="startMove('right')" onmouseup="stopMove('right')" ontouchend="stopMove('right')" ontouchstart="startMove('right')">➡️</button>
 </div>
 </div>
-<audio autoplay="" id="bg-music" loop="" src="assets/music.mp3" crossorigin="anonymous">
+<audio autoplay="" id="bg-music" loop="" src="assets/music.mp3">
     Your browser does not support the audio element.
 </audio>
-<audio id="pickup-sound" src="assets/flower_pickup.mp3" crossorigin="anonymous"></audio>
-<audio id="door-sound" src="assets/PIXEL CREAKING DOOR.mp3" crossorigin="anonymous"></audio>
+<audio id="pickup-sound" src="assets/flower_pickup.mp3"></audio>
+<audio id="door-sound" src="assets/PIXEL CREAKING DOOR.mp3"></audio>
 <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -816,7 +816,3 @@ updateDialogue();
 gameLoop();
 })();
 
-window.startMove = startMove;
-window.stopMove = stopMove;
-})();
-


### PR DESCRIPTION
## Summary
- remove strict CSP from HTML to allow local file loading
- drop unnecessary crossorigin attributes
- fix double IIFE closing in script

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686cae2de86c8328bb0b9fa88cff96fb