### PR TITLE
Add forest music switch

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,9 @@
 <audio autoplay="" id="bg-music" loop="" src="assets/music.mp3">
     Your browser does not support the audio element.
 </audio>
+<audio id="forest-music" loop="" src="assets/zelda_style_forest_chiptune.mp3">
+    Your browser does not support the audio element.
+</audio>
 <audio id="pickup-sound" src="assets/flower_pickup.mp3"></audio>
 <audio id="door-sound" src="assets/PIXEL CREAKING DOOR.mp3"></audio>
 <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -6,6 +6,7 @@
   const ctx = canvas.getContext('2d');
   const startScreenEl = document.getElementById('startScreen');
   const bgMusic = document.getElementById('bg-music');
+  const forestMusic = document.getElementById('forest-music');
   const pickupSound = document.getElementById('pickup-sound');
   const doorSound = document.getElementById('door-sound');
   const flowerPopup = document.getElementById('flower-popup');
@@ -394,6 +395,12 @@ function exitIndoor() {
 startScreenEl.addEventListener('click', () => {
   startScreenEl.style.display = 'none';
   if (bgMusic && bgMusic.play) bgMusic.play().catch(() => {});
+  if (forestMusic && forestMusic.play) {
+    forestMusic.play().then(() => {
+      forestMusic.pause();
+      forestMusic.currentTime = 0;
+    }).catch(() => {});
+  }
 });
 document.body.addEventListener('click', () => {
   if (bgMusic && bgMusic.paused) {
@@ -1188,6 +1195,11 @@ function checkInteractions() {
       hunterFollowStart = null;
       hunterFollowActive = false;
       player.y = canvas.height - player.h - 1;
+      if (bgMusic) bgMusic.pause();
+      if (forestMusic) {
+        forestMusic.currentTime = 0;
+        forestMusic.play().catch(() => {});
+      }
       isTalking = false;
       talkTarget = null;
       showTypedMessage = '';
@@ -1224,17 +1236,19 @@ function checkInteractions() {
       return;
     }
   }
-  else if (scene.current === 'forest') {
-    const inVertRoad = player.x + player.w > 140 && player.x < 160;
-    if (player.y + player.h >= canvas.height && inVertRoad) {
-      scene.current = 'outdoor';
-      player.y = 1;
-      isTalking = false;
-      talkTarget = null;
-      showTypedMessage = '';
-      return;
-    }
-  } else if (scene.current === 'camp') {
+    else if (scene.current === 'forest') {
+      const inVertRoad = player.x + player.w > 140 && player.x < 160;
+      if (player.y + player.h >= canvas.height && inVertRoad) {
+        scene.current = 'outdoor';
+        player.y = 1;
+        if (forestMusic) forestMusic.pause();
+        if (bgMusic && bgMusic.paused) bgMusic.play().catch(() => {});
+        isTalking = false;
+        talkTarget = null;
+        showTypedMessage = '';
+        return;
+      }
+    } else if (scene.current === 'camp') {
     const inVertRoad = player.x + player.w > 140 && player.x < 160;
     if (player.y <= 0 && inVertRoad) {
       scene.current = 'outdoor';


### PR DESCRIPTION
## Summary
- play special Zelda-style music when the player enters the forest
- resume main background music when leaving the forest
- preload forest music audio on start for smooth playback
- include forest music audio element in page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e001e576483288f1f95d667d84acb